### PR TITLE
Do not copy to system clipboard by default

### DIFF
--- a/lvim/.config/lvim/config.lua
+++ b/lvim/.config/lvim/config.lua
@@ -14,6 +14,8 @@ lvim.format_on_save = false
 vim.opt.relativenumber = true
 -- no mouse support
 vim.opt.mouse = ""
+-- no automatic system clipboard usage
+vim.opt.clipboard = ""
 -- no lines crossing usng cursor and h,l aka classic vim defaults
 vim.opt.whichwrap = "b,s"
 -- highlight column 80


### PR DESCRIPTION
Often I copy something from the browser to the system clipboard and then
switch to lvim and use the change command with a text object to
overwrite some text. Using the change command overwrites the system
clipboard which results in the loss of the previously copied text. This
is annoying the least said.

# Closes issue(s)

Fixes #18

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the README.md (if available and necessary)
