### PR TITLE
Eval bash hook of direnv only after Homebrew

### DIFF
--- a/bash/.config/bash/profile.Darwin
+++ b/bash/.config/bash/profile.Darwin
@@ -1,8 +1,5 @@
 # This file contains stuff that is specific for macOS
 
-# Add direnv bash hook
-eval "$(direnv hook bash)"
-
 # Make user installed python packages avallabel in PATH
 export PATH="$HOME/Library/Python/3.8/bin:$PATH"
 
@@ -16,6 +13,9 @@ fi
 
 # safe brew prefix
 brew_prefix=$(brew --prefix)
+
+# Add direnv bash hook
+eval "$(direnv hook bash)"
 
 # Source bash completion installed by Homebrew formula bashcompletion@2
 [[ -r "${brew_prefix}/etc/profile.d/bash_completion.sh" ]] && . "${brew_prefix}/etc/profile.d/bash_completion.sh"


### PR DESCRIPTION
On x86_64 architecture Homebrew installs in `/usr/local/bin`, which is
in PATH right away, while on arm64 Homebrew install in
`/opt/homebrew/bin`, which is in PATH only after initializing Homebrew.
Therefore switched order in profile.

# Closes issue(s)

Fixes #32

# Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the README.md (if available and necessary)
