### PR TITLE
Map moving lines to symbols

### DIFF
--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -23,6 +23,14 @@ map("n", "n", "nzzzv")
 map("n", "N", "Nzzzv")
 map("n", "gd", "gdzzzv")
 
+-- Move Lines
+-- map("n", "∆", "<cmd>m .+1<cr>==", { desc = "Move down" })
+-- map("n", "˚", "<cmd>m .-2<cr>==", { desc = "Move up" })
+-- map("i", "∆", "<esc><cmd>m .+1<cr>==gi", { desc = "Move down" })
+-- map("i", "˚", "<esc><cmd>m .-2<cr>==gi", { desc = "Move up" })
+-- map("v", "∆", ":m '>+1<cr>gv=gv", { desc = "Move down" })
+-- map("v", "˚", ":m '<-2<cr>gv=gv", { desc = "Move up" })
+
 --[[
   Using leader + y/Y to yank to unnameplus or paste from unnamedplus register.
   The register unnamedplus is the system's clipboard and is the default


### PR DESCRIPTION
With my keyboard layout I am now able again to press <A-k>/<A-j> which would normally
print a symbol but is now map to move lines up and down.

# Closes issue(s)

Fixes #55

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have updated the README.md (if available and necessary)
