### PR TITLE
Refactor weather functionality to plugin

### DIFF
--- a/config/wezterm/plugins/weather.lua
+++ b/config/wezterm/plugins/weather.lua
@@ -1,0 +1,29 @@
+local wezterm = require("wezterm")
+
+local M = {}
+
+-- Configuration
+M.config = {
+  location = "Burgdorf",
+  format = "%l:+%c%t%20%20%w%20%20%m",
+  timeout = 2,
+}
+
+-- Get current weather information
+function M.get_weather()
+  local url = string.format("wttr.in/%s?format=%s", M.config.location, M.config.format)
+  local success, stdout, _ = wezterm.run_child_process({
+    "curl",
+    "-m", tostring(M.config.timeout),
+    "--silent",
+    url,
+  })
+  
+  if not success or not stdout then
+    return ""
+  end
+  
+  return stdout
+end
+
+return M

--- a/config/wezterm/wezterm.lua
+++ b/config/wezterm/wezterm.lua
@@ -2,6 +2,7 @@
 local wezterm = require("wezterm")
 local keybindings = require("keybindings")
 local trackinfo = require("plugins.trackinfo")
+local weather = require("plugins.weather")
 
 -- Trim a strng
 function trim(s)
@@ -95,16 +96,7 @@ function update_trackinfo()
 end
 
 function update_weather()
-  local success, stdout, _ = wezterm.run_child_process({
-    "curl",
-    "-m 2",
-    "--silent",
-    "wttr.in/Burgdorf?format=%l:+%c%t%20%20%w%20%20%m",
-  })
-  if not success or not stdout then
-    wezterm.GLOBAL.current_weather = ""
-  end
-  wezterm.GLOBAL.current_weather = stdout
+  wezterm.GLOBAL.current_weather = weather.get_weather()
 end
 
 wezterm.on("update-status", function(window, pane)


### PR DESCRIPTION
Closes #51

This PR refactors the weather functionality into a dedicated plugin module for better code organization.

**Changes:**
- Created `plugins/weather.lua` module with clean API
- Added configurable location, format, and timeout settings
- Updated `wezterm.lua` to use the weather plugin
- Simplified `update_weather()` function

This follows the same pattern as the trackinfo plugin refactoring in #71, making the wezterm configuration more modular and maintainable.